### PR TITLE
upgrade springdoc to 1.3.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /.project
 /.settings/
+.idea
+*.iml

--- a/department-service/pom.xml
+++ b/department-service/pom.xml
@@ -62,7 +62,7 @@
 		<dependency>
 			<groupId>org.springdoc</groupId>
 			<artifactId>springdoc-openapi-webmvc-core</artifactId>
-			<version>1.2.32</version>
+			<version>1.3.4</version>
 		</dependency>
 	</dependencies>
 
@@ -74,5 +74,5 @@
 			</plugin>
 		</plugins>
 	</build>
-	
+
 </project>

--- a/employee-service/pom.xml
+++ b/employee-service/pom.xml
@@ -55,7 +55,7 @@
 		<dependency>
 			<groupId>org.springdoc</groupId>
 			<artifactId>springdoc-openapi-webmvc-core</artifactId>
-			<version>1.2.32</version>
+			<version>1.3.4</version>
 		</dependency>
 	</dependencies>
 

--- a/gateway-service/pom.xml
+++ b/gateway-service/pom.xml
@@ -34,12 +34,12 @@
 		<dependency>
 			<groupId>org.springdoc</groupId>
 			<artifactId>springdoc-openapi-webflux-core</artifactId>
-			<version>1.2.31</version>
+			<version>1.3.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springdoc</groupId>
 			<artifactId>springdoc-openapi-webflux-ui</artifactId>
-			<version>1.2.31</version>
+			<version>1.3.4</version>
 		</dependency>
 	</dependencies>
 

--- a/gateway-service/src/main/java/pl/piomin/services/gateway/GatewayApplication.java
+++ b/gateway-service/src/main/java/pl/piomin/services/gateway/GatewayApplication.java
@@ -1,15 +1,12 @@
 package pl.piomin.services.gateway;
 
-import io.swagger.v3.oas.models.OpenAPI;
-import io.swagger.v3.oas.models.PathItem;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springdoc.core.GroupedOpenApi;
-import org.springdoc.core.customizers.OpenApiCustomiser;
+import org.springdoc.core.SwaggerUiConfigProperties;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
 import org.springframework.cloud.gateway.route.RouteDefinition;
 import org.springframework.cloud.gateway.route.RouteDefinitionLocator;
 import org.springframework.context.annotation.Bean;
@@ -31,11 +28,12 @@ public class GatewayApplication {
 	RouteDefinitionLocator locator;
 
 	@Bean
-	public List<GroupedOpenApi> apis() {
+	public List<GroupedOpenApi> apis(SwaggerUiConfigProperties swaggerUiConfigProperties) {
 		List<GroupedOpenApi> groups = new ArrayList<>();
 		List<RouteDefinition> definitions = locator.getRouteDefinitions().collectList().block();
 		definitions.stream().filter(routeDefinition -> routeDefinition.getId().matches(".*-service")).forEach(routeDefinition -> {
 			String name = routeDefinition.getId().replaceAll("-service", "");
+            swaggerUiConfigProperties.addGroup(name);
 			GroupedOpenApi.builder().pathsToMatch("/" + name + "/**").setGroup(name).build();
 		});
 		return groups;

--- a/organization-service/pom.xml
+++ b/organization-service/pom.xml
@@ -62,7 +62,7 @@
 		<dependency>
 			<groupId>org.springdoc</groupId>
 			<artifactId>springdoc-openapi-webmvc-core</artifactId>
-			<version>1.2.32</version>
+			<version>1.3.4</version>
 		</dependency>
 	</dependencies>
 
@@ -74,5 +74,5 @@
 			</plugin>
 		</plugins>
 	</build>
-	
+
 </project>


### PR DESCRIPTION
upgrade springdoc to 1.3.4 [refer origin commit](https://github.com/springdoc/springdoc-openapi/commit/f4943466e90884148ed9bc8920675ab6c6b8fc01)

#21 
> Hi, I recreated the project structure locally to learn about microservices, I am using springdoc 1.3.9. After updating to 1.3.4, did you notice anything? In my build the selector in the top bar for the apis is gone.

Yes, there will be similar problems when upgrading to the new version after 1.3.4. this PR has solved this problem.the key code is `swaggerUiConfigProperties.addGroup(name);`