### PR TITLE
Fixes piomin/sample-spring-microservices-new#87

### DIFF
--- a/department-service/pom.xml
+++ b/department-service/pom.xml
@@ -59,6 +59,10 @@
             <artifactId>opentelemetry-exporter-zipkin</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.github.openfeign</groupId>
+            <artifactId>feign-micrometer</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-starter-webmvc-api</artifactId>
             <version>2.2.0</version>

--- a/employee-service/pom.xml
+++ b/employee-service/pom.xml
@@ -51,6 +51,10 @@
             <artifactId>opentelemetry-exporter-zipkin</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.github.openfeign</groupId>
+            <artifactId>feign-micrometer</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-starter-webmvc-api</artifactId>
             <version>2.2.0</version>

--- a/organization-service/pom.xml
+++ b/organization-service/pom.xml
@@ -52,6 +52,10 @@
             <artifactId>opentelemetry-exporter-zipkin</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.github.openfeign</groupId>
+            <artifactId>feign-micrometer</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>


### PR DESCRIPTION
The traces are not spanning into multiple services via the @FeignClient, but it can be fixed by including the feign-micrometer dependency. 

Traces before the fix:
```
organization-service:
|           [b2cce3535bb36f51180845d0225fae12,f335828d351f0877] - INFO Organization find: id=1
|-> department-service: 
     |      [445a76f99945265f7ed319c24fc6b689,c3bd9f888791aea3] - INFO Department find: organizationId=1
     |->employee-service: 
         |  [ff19e04be570e3fd9b08561a2ba7222e,f8af53cf460cd077] - INFO Employee find: departmentId=1
         |  [89c018ad0dacdc1d9d66828ec722bf40,4cfd6dc63bf109d4] - INFO Employee find: departmentId=2 
```

Traces after the fix:
```
organization-service:
|           [602deafe3be8835d930ad8398e86e667,2483fc5f46a0337a] - INFO Organization find: id=1
|-> department-service: 
     |      [602deafe3be8835d930ad8398e86e667,66c9c99651b48d41] - INFO Department find: organizationId=1
     |->employee-service: 
         |  [602deafe3be8835d930ad8398e86e667,704c3f086d4fad32] - INFO Employee find: departmentId=1
         |  [602deafe3be8835d930ad8398e86e667,3b1aaf7652c71b13] - INFO Employee find: departmentId=2
```

This was suggested in the spring cloud feign documentation @ https://docs.spring.io/spring-cloud-openfeign/docs/current/reference/html/#micrometer-support 
